### PR TITLE
Refactor app-dependent metric names

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,89 +25,113 @@ var HAProxyProducer = module.exports = function(options) {
           return;
         }
 
-        var service = ['haproxy', section.pxname, section.svname].join('.');
+        var service = 'haproxy';
 
         if (section.qcur) {
           emitter.metric({
             name: service + '.queued-requests',
-            value: parseInt(section.qcur, 10)
+            value: parseInt(section.qcur, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.bin) {
           emitter.metric({
             name: service + '.bytes-in',
-            value: parseInt(section.bin, 10)
+            value: parseInt(section.bin, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.bout) {
           emitter.metric({
             name: service + '.bytes-out',
-            value: parseInt(section.bout, 10)
+            value: parseInt(section.bout, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.rate) {
           emitter.metric({
             name: service + '.rate',
-            value: parseInt(section.rate, 10)
+            value: parseInt(section.rate, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.ereq) {
           emitter.metric({
             name: service + '.request-errors',
-            value: parseInt(section.ereq, 10)
+            value: parseInt(section.ereq, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.econ) {
           emitter.metric({
             name: service + '.connection-errors',
-            value: parseInt(section.econ, 10)
+            value: parseInt(section.econ, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.eresp) {
           emitter.metric({
             name: service + '.response-errors',
-            value: parseInt(section.eresp, 10)
+            value: parseInt(section.eresp, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.hrsp_1xx) {
           emitter.metric({
             name: service + '.http-1xx',
-            value: parseInt(section.hrsp_1xx, 10)
+            value: parseInt(section.hrsp_1xx, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.hrsp_2xx) {
           emitter.metric({
             name: service + '.http-2xx',
-            value: parseInt(section.hrsp_2xx, 10)
+            value: parseInt(section.hrsp_2xx, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.hrsp_3xx) {
           emitter.metric({
             name: service + '.http-3xx',
-            value: parseInt(section.hrsp_3xx, 10)
+            value: parseInt(section.hrsp_3xx, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.hrsp_4xx) {
           emitter.metric({
             name: service + '.http-4xx',
-            value: parseInt(section.hrsp_4xx, 10)
+            value: parseInt(section.hrsp_4xx, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
 
         if (section.hrsp_5xx) {
           emitter.metric({
             name: service + '.http-5xx',
-            value: parseInt(section.hrsp_5xx, 10)
+            value: parseInt(section.hrsp_5xx, 10),
+            pxname: section.pxname,
+            svname: section.svname
           });
         }
       });


### PR DESCRIPTION
Grafana is not able to wildcard measurement names, but it is able to use
tags for its graphing.

cc @ceejbot 
