### PR TITLE
Compute deltas between certain HAProxy stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ var HAProxyProducer = module.exports = function(options) {
 
       info.forEach(function (section) {
         function delta(stat) {
-          if (!previous) throw new Error('No previous stats bundle available');
           var previousSection = previous.filter(function (previousSection) {
             return previousSection.pxname === section.pxname &&
                    previousSection.svname === section.svname;


### PR DESCRIPTION
For some statistics (for example, number of 2xx's) HAProxy gives us
totals from its entire lifetime, where for graphing and analysis we only
care about deltas between intervals.

cc @ceejbot 
